### PR TITLE
fix: terminal flicker on mobile — debounce resize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-tunnel",
-  "version": "1.2.0-beta.13",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-tunnel",
-      "version": "1.2.0-beta.13",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "node-pty": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-tunnel",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Tunnel any CLI app to your phone — PTY + devtunnel + xterm.js",
   "type": "module",
   "main": "dist/index.js",

--- a/remote-ui/app.js
+++ b/remote-ui/app.js
@@ -93,15 +93,24 @@
     fitAddon.fit();
 
     // Send terminal size to PTY so copilot renders correctly
+    var lastCols = 0, lastRows = 0;
+    var resizeTimer = null;
     function sendResize() {
       if (ws && ws.readyState === WebSocket.OPEN && xterm) {
-        ws.send(JSON.stringify({ type: 'pty_resize', cols: xterm.cols, rows: xterm.rows }));
+        if (xterm.cols !== lastCols || xterm.rows !== lastRows) {
+          lastCols = xterm.cols;
+          lastRows = xterm.rows;
+          ws.send(JSON.stringify({ type: 'pty_resize', cols: xterm.cols, rows: xterm.rows }));
+        }
       }
     }
 
-    // Handle resize
+    // Handle resize — debounced to avoid rapid PTY resizes (mobile keyboard, URL bar, etc.)
     window.addEventListener('resize', () => {
-      if (fitAddon) { fitAddon.fit(); sendResize(); }
+      if (resizeTimer) clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => {
+        if (fitAddon) { fitAddon.fit(); sendResize(); }
+      }, 150);
     });
 
     // Send initial size
@@ -568,18 +577,25 @@
     }, 100);
   }
 
+  var gridResizeTimer = null;
   function fitGridPanels() {
-    gridTerminals.forEach(function(gt) {
-      if (!document.contains(gt.panel)) return;
-      if (gt.fitAddon) {
-        try {
-          gt.fitAddon.fit();
-          if (gt.ws && gt.ws.readyState === WebSocket.OPEN && gt.xterm) {
-            gt.ws.send(JSON.stringify({ type: 'pty_resize', cols: gt.xterm.cols, rows: gt.xterm.rows }));
-          }
-        } catch(e) {}
-      }
-    });
+    if (gridResizeTimer) clearTimeout(gridResizeTimer);
+    gridResizeTimer = setTimeout(function() {
+      gridTerminals.forEach(function(gt) {
+        if (!document.contains(gt.panel)) return;
+        if (gt.fitAddon) {
+          try {
+            var prevCols = gt.xterm ? gt.xterm.cols : 0;
+            var prevRows = gt.xterm ? gt.xterm.rows : 0;
+            gt.fitAddon.fit();
+            if (gt.ws && gt.ws.readyState === WebSocket.OPEN && gt.xterm &&
+                (gt.xterm.cols !== prevCols || gt.xterm.rows !== prevRows)) {
+              gt.ws.send(JSON.stringify({ type: 'pty_resize', cols: gt.xterm.cols, rows: gt.xterm.rows }));
+            }
+          } catch(e) {}
+        }
+      });
+    }, 150);
   }
 
   function destroyGrid() {
@@ -833,7 +849,8 @@
     ws.onopen = () => {
       connected = true;
       reconnectAttempt = 0;
-      setTimeout(() => initializeACP(1), 1000);
+      setStatus('online', 'Connected');
+      // PTY mode: server sends pty data immediately, no ACP handshake needed
     };
     ws.onclose = () => {
       connected = false; acpReady = false; sessionId = null;


### PR DESCRIPTION
## Problem
On mobile browsers, every minor viewport change (keyboard open/close, URL bar hide/show) fired a window resize event, causing:
- Immediate \pty_resize\ sent to server
- CLI app (copilot, etc.) fully redraws for new dimensions
- Visible screen flicker + extra lines appearing

## Fix
- **Debounced resize** (150ms) — batches rapid resize events into one
- **Dimension check** — only sends \pty_resize\ when cols/rows actually changed
- **Removed ACP init** — \initializeACP()\ was called on every WS open but PTY mode doesn't use ACP, causing unnecessary system messages
- **Grid panel resize debounced** too

## Testing
- 32/32 tests pass
- Build clean