### PR TITLE
fix: reset resize state on WS reconnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-tunnel",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-tunnel",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "node-pty": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-tunnel",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Tunnel any CLI app to your phone — PTY + devtunnel + xterm.js",
   "type": "module",
   "main": "dist/index.js",

--- a/remote-ui/app.js
+++ b/remote-ui/app.js
@@ -113,8 +113,7 @@
       }, 150);
     });
 
-    // Send initial size
-    setTimeout(sendResize, 500);
+    // Initial size is sent on WS open (see ws.onopen)
 
     // Keyboard input → send to bridge → PTY
     xterm.onData((data) => {
@@ -850,7 +849,8 @@
       connected = true;
       reconnectAttempt = 0;
       setStatus('online', 'Connected');
-      // PTY mode: server sends pty data immediately, no ACP handshake needed
+      // Reset resize tracking so initial pty_resize is always sent on new connection
+      if (xterm) { lastCols = 0; lastRows = 0; sendResize(); }
     };
     ws.onclose = () => {
       connected = false; acpReady = false; sessionId = null;


### PR DESCRIPTION
Fixes Copilot review comment on PR #3: after WS reconnect, \lastCols/lastRows\ persisted from the previous connection, preventing the initial \pty_resize\ from being sent. The server's new PTY didn't know the terminal size.

Reset to 0 on every \ws.onopen\ and send resize immediately.