### PR TITLE
fix: make Origin header optional for devtunnel compatibility (v1.4.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-tunnel",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Tunnel any CLI app to your phone — PTY + devtunnel + xterm.js",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -429,19 +429,17 @@ const wss = new WebSocketServer({
 
     // F-18: Session expiry
     if (Date.now() - sessionCreatedAt > SESSION_TTL) return false;
-    // F-3: Validate origin BEFORE ticket acceptance
-    // F-06: Require Origin header — reject non-browser clients without Origin
+    // F-3: Validate origin when present (devtunnel proxies may strip it)
     const origin = info.req.headers.origin;
-    if (!origin) {
-      return false;
+    if (origin) {
+      try {
+        const originUrl = new URL(origin);
+        const host = originUrl.hostname;
+        if (host !== 'localhost' && host !== '127.0.0.1' && !host.endsWith('.devtunnels.ms')) {
+          return false;
+        }
+      } catch { return false; }
     }
-    try {
-      const originUrl = new URL(origin);
-      const host = originUrl.hostname;
-      if (host !== 'localhost' && host !== '127.0.0.1' && !host.endsWith('.devtunnels.ms')) {
-        return false;
-      }
-    } catch { return false; }
     const url = new URL(info.req.url!, `http://${info.req.headers.host}`);
     // F-02: Accept one-time ticket (only auth method for WS)
     const ticket = url.searchParams.get('ticket');


### PR DESCRIPTION
The verifyClient required an Origin header on WebSocket connections. Devtunnel proxies may strip this header when forwarding upgrades, causing direct connections via devtunnel to fail silently (stuck on Connecting).

Fix: validate Origin when present (reject bad origins), but allow connections without it. Ticket-based auth is the real security gate.

Bumps version to 1.4.1.