### PR TITLE
fix: var/const conflict crashes connect() — stuck on Connecting (v1.4.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-tunnel",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Tunnel any CLI app to your phone — PTY + devtunnel + xterm.js",
   "type": "module",
   "main": "dist/index.js",

--- a/remote-ui/app.js
+++ b/remote-ui/app.js
@@ -977,7 +977,7 @@
       history.replaceState(null, '', cleanUrl.toString());
     }
 
-    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
 
     // If we have a ticket (from hub Connect button), use it directly
     if (ticketParam) {
@@ -985,7 +985,7 @@
     } else {
       // Exchange token for ticket
       try {
-        const resp = await fetch('/api/auth/ticket', {
+        var resp = await fetch('/api/auth/ticket', {
           method: 'POST',
           headers: { 'Authorization': 'Bearer ' + savedToken }
         });


### PR DESCRIPTION
The hub WS code used var proto/resp inside the isHubMode block. The direct connect path used const proto/resp. Since var hoists to function scope, the const redeclaration throws 'Identifier proto has already been declared', crashing connect() entirely. Status stuck on 'Connecting...' forever.

Fix: use var consistently. Verified working in browser.